### PR TITLE
Remove border on navbar

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -19,6 +19,7 @@ a:hover {
   border-bottom: 1px solid #9e9e9e;
 }
 .navbar {
+  border: 0;
   margin-bottom: 0;
 }
 .header {


### PR DESCRIPTION
So I noticed the navigation menu, when highlighted, does not fill the entire navbar container. Seen below (zoomed in). 
![image](https://user-images.githubusercontent.com/8700123/83960834-3e045280-a842-11ea-9b10-47b18e8dc8c0.png)

Not sure if intended, but adding a border 0 to the navbar class will remove this.
Tested on Firefox and Chrome.