### PR TITLE
Use bind mount to persist mariadb data

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,7 @@ WATCH_DIR=/home/soruly/trace.moe-incoming/  # suggest using fast drives
 MEDIA_DIR=/home/soruly/trace.moe-media/     # suggest using large drives
 HASH_DIR=/home/soruly/trace.moe-hash/       # suggest using fast drives
 SOLR_DIR=/home/soruly/mycores               # suggest using super fast drives
+MYSQL_DIR=/home/soruly/mysql 
 
 TRACE_MEDIA_SALT=YOUR_TRACE_MEDIA_SALT
 TRACE_API_SALT=YOUR_TRACE_API_SALT

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ WATCH_DIR=/home/soruly/trace.moe-incoming/  # suggest using fast drives
 MEDIA_DIR=/home/soruly/trace.moe-media/     # suggest using large drives
 HASH_DIR=/home/soruly/trace.moe-hash/       # suggest using fast drives
 SOLR_DIR=/home/soruly/mycores               # suggest using super fast drives
+MYSQL_DIR=/home/soruly/mysql
 
 TRACE_MEDIA_SALT=YOUR_TRACE_MEDIA_SALT
 TRACE_API_SALT=YOUR_TRACE_API_SALT
@@ -98,6 +99,7 @@ mkdir -p /home/soruly/trace.moe-incoming/
 mkdir -p /home/soruly/trace.moe-media/
 mkdir -p /home/soruly/trace.moe-hash/
 mkdir -p /home/soruly/mycores
+mkdir -p /home/soruly/mysql
 sudo chown 8983:8983 /home/soruly/mycores
 ```
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -72,6 +72,10 @@ services:
     restart: unless-stopped
     environment:
       - MARIADB_ROOT_PASSWORD=${MARIADB_ROOT_PASSWORD}
+    volumes:
+      - type: bind
+        source: ${MYSQL_DIR}
+        target: /var/lib/mysql
     networks:
       trace_moe_net:
 


### PR DESCRIPTION
Currently when using docker-compose to start the trace.moe system, the mariadb container uses ephemeral docker volumes to store data and it would be lost when "docker-compose down". 

The sad situation is that the query log and all the metadata collected during the indexing process will be removed. 

A better practice is to persist those SQL data at the host machine. Here comes this PR.

Relevant StackOverflow question: https://stackoverflow.com/questions/39175194/docker-compose-persistent-data-mysql/